### PR TITLE
[Shieldfy] security update 'mathjs' from 3.10.1 to  & morgan' from 1.9.0 to  & node-serialize' from 0.0.4 to 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,36 +1,36 @@
 {
-  "name": "dvna",
-  "version": "0.0.1",
-  "description": "Damn Vulnerable NodeJS Application",
-  "main": "server.js",
-  "directories": {
-    "doc": "docs"
-  },
-  "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
-    "start": "node server.js"
-  },
-  "author": "sns",
-  "license": "MIT",
-  "dependencies": {
-    "bcrypt": "^1.0.3",
-    "csurf": "^1.9.0",
-    "ejs": "^2.5.7",
-    "express": "^4.16.2",
-    "express-fileupload": "^0.4.0",
-    "express-flash": "0.0.2",
-    "express-session": "^1.15.6",
-    "flash": "^1.1.0",
-    "libxmljs": "^0.19.1",
-    "mathjs": "3.10.1",
-    "md5": "^2.2.1",
-    "morgan": "^1.9.0",
-    "mysql2": "^1.4.2",
-    "node-serialize": "0.0.4",
-    "passport": "^0.4.0",
-    "passport-local": "^1.0.0",
-    "sequelize": "^4.13.10",
-    "winston": "^3.0.0",
-    "x-xss-protection": "^1.1.0"
-  }
+    "name": "dvna",
+    "version": "0.0.1",
+    "description": "Damn Vulnerable NodeJS Application",
+    "main": "server.js",
+    "directories": {
+        "doc": "docs"
+    },
+    "scripts": {
+        "test": "echo \"Error: no test specified\" && exit 1",
+        "start": "node server.js"
+    },
+    "author": "sns",
+    "license": "MIT",
+    "dependencies": {
+        "bcrypt": "^1.0.3",
+        "csurf": "^1.9.0",
+        "ejs": "^2.5.7",
+        "express": "^4.16.2",
+        "express-fileupload": "^0.4.0",
+        "express-flash": "0.0.2",
+        "express-session": "^1.15.6",
+        "flash": "^1.1.0",
+        "libxmljs": "^0.19.1",
+        "mathjs": null,
+        "md5": "^2.2.1",
+        "morgan": null,
+        "mysql2": "^1.4.2",
+        "node-serialize": null,
+        "passport": "^0.4.0",
+        "passport-local": "^1.0.0",
+        "sequelize": "^4.13.10",
+        "winston": "^3.0.0",
+        "x-xss-protection": "^1.1.0"
+    }
 }


### PR DESCRIPTION
This pull request contains a bunch of enhancements and bug-fixes, happily shared with you